### PR TITLE
We can now add users that are offline

### DIFF
--- a/fagiServer/src/InputWorker.java
+++ b/fagiServer/src/InputWorker.java
@@ -432,8 +432,11 @@ public class InputWorker extends Worker {
         if (!(response instanceof AllIsWell)) {
             return response;
         }
-        Data.getInputWorker(arg.getFriendUsername())
-            .handleInput(new GetFriendListRequest(arg.getFriendUsername()));
+
+        if (Data.isUserOnline(arg.getFriendUsername())) {
+            Data.getInputWorker(arg.getFriendUsername())
+                .handleInput(new GetFriendListRequest(arg.getFriendUsername()));
+        }
         return getFriendList();
     }
 }


### PR DESCRIPTION
We assumed that the other user was online which resulted in the server getting a null pointer and crashed the connection to the client responsible