### PR TITLE
Fixing logintests

### DIFF
--- a/fagiClient/test/src/com/fagi/guitests/CreatePasswordTests.java
+++ b/fagiClient/test/src/com/fagi/guitests/CreatePasswordTests.java
@@ -10,6 +10,7 @@ import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
 import javafx.scene.control.PasswordField;
+import javafx.scene.layout.AnchorPane;
 import javafx.stage.Stage;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -18,7 +19,7 @@ import org.mockito.Mockito;
 import org.testfx.framework.junit.ApplicationTest;
 
 public class CreatePasswordTests extends ApplicationTest {
-    private MasterLogin spy;
+    private MasterLogin masterLogin;
 
     @BeforeClass
     public static void initialize() {
@@ -80,7 +81,7 @@ public class CreatePasswordTests extends ApplicationTest {
         Node btn = lookup("#loginBtn").query();
         clickOn(btn);
 
-        Assert.assertEquals(LoginState.INVITE_CODE, spy.getState());
+        Assert.assertEquals(LoginState.INVITE_CODE, masterLogin.getState());
         Assert.assertNotNull(lookup("#UniqueInviteCode"));
     }
 
@@ -94,15 +95,12 @@ public class CreatePasswordTests extends ApplicationTest {
         ChatManager.setCommunication(communication);
         ChatManager.setApplication(fagiApp);
 
-        MasterLogin masterLogin = new MasterLogin(fagiApp, communication, stage, draggable);
+        stage.setScene(new Scene(new AnchorPane()));
+        masterLogin = new MasterLogin(fagiApp, communication, stage, draggable);
         masterLogin.setState(LoginState.PASSWORD);
-        spy = Mockito.spy(masterLogin);
+        masterLogin.showMasterLoginScreen();
 
-        Mockito.doNothing().when(spy).updateRoot();
-        spy.showMasterLoginScreen();
-        Mockito.doCallRealMethod().when(spy).updateRoot();
-
-        stage.setScene(new Scene(spy.getController().getParentNode()));
+        stage.getScene().setRoot(masterLogin.getController().getParentNode());
         stage.show();
     }
 }

--- a/fagiClient/test/src/com/fagi/guitests/CreateUserNameTests.java
+++ b/fagiClient/test/src/com/fagi/guitests/CreateUserNameTests.java
@@ -12,6 +12,7 @@ import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
 import javafx.scene.control.TextField;
+import javafx.scene.layout.AnchorPane;
 import javafx.stage.Stage;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -21,7 +22,7 @@ import org.testfx.framework.junit.ApplicationTest;
 
 public class CreateUserNameTests extends ApplicationTest {
     private Communication communication;
-    private MasterLogin spy;
+    private MasterLogin masterLogin;
 
     @BeforeClass
     public static void initialize() {
@@ -82,7 +83,7 @@ public class CreateUserNameTests extends ApplicationTest {
         Node nextBtn = lookup("#loginBtn").query();
         clickOn(nextBtn);
 
-        Assert.assertEquals(LoginState.PASSWORD, spy.getState());
+        Assert.assertEquals(LoginState.PASSWORD, masterLogin.getState());
         Assert.assertNotNull(lookup("#passwordRepeat"));
     }
 
@@ -149,15 +150,12 @@ public class CreateUserNameTests extends ApplicationTest {
         ChatManager.setCommunication(communication);
         ChatManager.setApplication(fagiApp);
 
-        MasterLogin masterLogin = new MasterLogin(fagiApp, communication, stage, draggable);
+        stage.setScene(new Scene(new AnchorPane()));
+        masterLogin = new MasterLogin(fagiApp, communication, stage, draggable);
         masterLogin.setState(LoginState.USERNAME);
-        spy = Mockito.spy(masterLogin);
+        masterLogin.showMasterLoginScreen();
 
-        Mockito.doNothing().when(spy).updateRoot();
-        spy.showMasterLoginScreen();
-        Mockito.doCallRealMethod().when(spy).updateRoot();
-
-        stage.setScene(new Scene(spy.getController().getParentNode()));
+        stage.getScene().setRoot(masterLogin.getController().getParentNode());
         stage.show();
     }
 }

--- a/fagiClient/test/src/com/fagi/guitests/InviteCodeTests.java
+++ b/fagiClient/test/src/com/fagi/guitests/InviteCodeTests.java
@@ -11,6 +11,7 @@ import com.fagi.responses.IllegalInviteCode;
 import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.control.Label;
+import javafx.scene.layout.AnchorPane;
 import javafx.stage.Stage;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -20,7 +21,7 @@ import org.testfx.framework.junit.ApplicationTest;
 
 public class InviteCodeTests extends ApplicationTest {
     private Communication communication;
-    private MasterLogin spy;
+    private MasterLogin masterLogin;
 
     @BeforeClass
     public static void initialize() {
@@ -41,7 +42,7 @@ public class InviteCodeTests extends ApplicationTest {
 
         Label messageLabel = lookup("#messageLabel").query();
 
-        Assert.assertEquals(LoginState.INVITE_CODE, spy.getState());
+        Assert.assertEquals(LoginState.INVITE_CODE, masterLogin.getState());
         Assert.assertEquals("Error: Illegal invite code. Contact host", messageLabel.getText());
     }
 
@@ -67,7 +68,7 @@ public class InviteCodeTests extends ApplicationTest {
         Node btn = lookup("#loginBtn").query();
         clickOn(btn);
 
-        Assert.assertEquals(LoginState.LOGIN, spy.getState());
+        Assert.assertEquals(LoginState.LOGIN, masterLogin.getState());
         Assert.assertNotNull(lookup("#UniqueLoginScreen").query());
     }
 
@@ -81,18 +82,16 @@ public class InviteCodeTests extends ApplicationTest {
         ChatManager.setCommunication(communication);
         ChatManager.setApplication(fagiApp);
 
-        MasterLogin masterLogin = new MasterLogin(fagiApp, communication, stage, draggable);
+        stage.setScene(new Scene(new AnchorPane()));
+        masterLogin = new MasterLogin(fagiApp, communication, stage, draggable);
         masterLogin.setState(LoginState.INVITE_CODE);
-        spy = Mockito.spy(masterLogin);
 
-        Mockito.doNothing().when(spy).updateRoot();
-        spy.showMasterLoginScreen();
-        Mockito.doCallRealMethod().when(spy).updateRoot();
+        masterLogin.showMasterLoginScreen();
 
-        spy.setUsername("ThisIsAUsername");
-        spy.setPassword("ThisIsAPassword");
+        masterLogin.setUsername("ThisIsAUsername");
+        masterLogin.setPassword("ThisIsAPassword");
 
-        stage.setScene(new Scene(spy.getController().getParentNode()));
+        stage.getScene().setRoot(masterLogin.getController().getParentNode());
         stage.show();
     }
 }

--- a/fagiClient/test/src/com/fagi/guitests/LoginTests.java
+++ b/fagiClient/test/src/com/fagi/guitests/LoginTests.java
@@ -15,6 +15,7 @@ import javafx.scene.Scene;
 import javafx.scene.control.Label;
 import javafx.scene.control.PasswordField;
 import javafx.scene.control.TextField;
+import javafx.scene.layout.AnchorPane;
 import javafx.stage.Stage;
 import org.junit.Assert;
 import org.junit.BeforeClass;
@@ -25,7 +26,7 @@ import org.testfx.framework.junit.ApplicationTest;
 import java.io.IOException;
 
 public class LoginTests extends ApplicationTest {
-    private MasterLogin spy;
+    private MasterLogin masterLogin;
     private Communication communication;
 
     @BeforeClass
@@ -120,7 +121,7 @@ public class LoginTests extends ApplicationTest {
 
     @Test
     public void WhenCallingSetMessageLabel_NewMessageShouldAppear() {
-        spy.setMessageLabel("Connection refused");
+        masterLogin.setMessageLabel("Connection refused");
 
         Label messageLabel = lookup("#messageLabel").query();
         Assert.assertEquals("Connection refused", messageLabel.getText());
@@ -131,7 +132,7 @@ public class LoginTests extends ApplicationTest {
         Node btn = lookup("#newAccount").query();
         clickOn(btn);
 
-        Assert.assertEquals(LoginState.USERNAME, spy.getState());
+        Assert.assertEquals(LoginState.USERNAME, masterLogin.getState());
         Assert.assertNotNull(lookup("#UniqueCreateUsernameView").query());
     }
 
@@ -145,14 +146,11 @@ public class LoginTests extends ApplicationTest {
         ChatManager.setCommunication(communication);
         ChatManager.setApplication(fagiApp);
 
-        MasterLogin masterLogin = new MasterLogin(fagiApp, communication, stage, draggable);
-        spy = Mockito.spy(masterLogin);
+        stage.setScene(new Scene(new AnchorPane()));
+        masterLogin = new MasterLogin(fagiApp, communication, stage, draggable);
+        masterLogin.showMasterLoginScreen();
 
-        Mockito.doNothing().when(spy).updateRoot();
-        spy.showMasterLoginScreen();
-        Mockito.doCallRealMethod().when(spy).updateRoot();
-
-        stage.setScene(new Scene(spy.getController().getParentNode()));
+        stage.getScene().setRoot(masterLogin.getController().getParentNode());
         stage.show();
     }
 }

--- a/fagiClient/test/src/com/fagi/guitests/LoginTests.java
+++ b/fagiClient/test/src/com/fagi/guitests/LoginTests.java
@@ -114,6 +114,11 @@ public class LoginTests extends ApplicationTest {
     public void WhenCallingSetMessageLabel_NewMessageShouldAppear() {
         masterLogin.setMessageLabel("Connection refused");
 
+        try {
+            Thread.sleep(100);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
         Label messageLabel = lookup("#messageLabel").query();
         Assert.assertEquals("Connection refused", messageLabel.getText());
     }

--- a/fagiClient/test/src/com/fagi/guitests/LoginTests.java
+++ b/fagiClient/test/src/com/fagi/guitests/LoginTests.java
@@ -1,6 +1,5 @@
 package com.fagi.guitests;
 
-import com.fagi.config.ServerConfig;
 import com.fagi.controller.login.MasterLogin;
 import com.fagi.controller.utility.Draggable;
 import com.fagi.enums.LoginState;
@@ -23,8 +22,6 @@ import org.junit.Test;
 import org.mockito.Mockito;
 import org.testfx.framework.junit.ApplicationTest;
 
-import java.io.IOException;
-
 public class LoginTests extends ApplicationTest {
     private MasterLogin masterLogin;
     private Communication communication;
@@ -32,12 +29,6 @@ public class LoginTests extends ApplicationTest {
     @BeforeClass
     public static void initialize() {
         System.out.println("Starting login tests");
-        ServerConfig config = new ServerConfig("test", "127.0.0.1", 1337, null);
-        try {
-            config.saveToPath("config/serverinfo.config");
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
     }
 
     @Test


### PR DESCRIPTION
Spying is not necessary in the following tests modified.
In addition the underlying problem was the threading between `Platform.runLater` and the execution of the `LoginTest`.
In addition this removes the need for the serverconfig file.