### PR TITLE
Make Workers more testable

### DIFF
--- a/fagiServer/src/main/java/com/fagi/handler/InputHandler.java
+++ b/fagiServer/src/main/java/com/fagi/handler/InputHandler.java
@@ -51,7 +51,7 @@ import java.util.stream.Collectors;
 
 public record InputHandler(InputAgent inputAgent, OutputAgent out, ConversationHandler conversationHandler, Data data) {
     public void handleInput(Object input) {
-        if (Objects.isNull(input)) {
+        if (input == null) {
             System.out.println("Input is null. Doing nothing.");
         } else if (input instanceof TextMessage arg) {
             MessageInfo messageInfo = arg.getMessageInfo();

--- a/fagiServer/src/main/java/com/fagi/handler/InputHandler.java
+++ b/fagiServer/src/main/java/com/fagi/handler/InputHandler.java
@@ -51,7 +51,9 @@ import java.util.stream.Collectors;
 
 public record InputHandler(InputAgent inputAgent, OutputAgent out, ConversationHandler conversationHandler, Data data) {
     public void handleInput(Object input) {
-        if (input instanceof TextMessage arg) {
+        if (Objects.isNull(input)) {
+            System.out.println("Input is null. Doing nothing.");
+        } else if (input instanceof TextMessage arg) {
             MessageInfo messageInfo = arg.getMessageInfo();
             messageInfo.setTimestamp(new Timestamp(System.currentTimeMillis()));
             out.addResponse(handleTextMessage(arg));

--- a/fagiServer/src/main/java/com/fagi/server/Server.java
+++ b/fagiServer/src/main/java/com/fagi/server/Server.java
@@ -20,6 +20,8 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.URL;
@@ -48,7 +50,12 @@ public class Server {
                     .getKey())
                     .key()
                     .getPublic();
-            ServerConfig config = new ServerConfig(name, ip, port, pk);
+            ServerConfig config = new ServerConfig(
+                    name,
+                    ip,
+                    port,
+                    pk
+            );
             config.saveToPath(configFile);
             File inviteCodesFile = new File(JsonFileOperations.INVITE_CODES_FILE_PATH);
             if (!inviteCodesFile.exists()) {
@@ -98,9 +105,17 @@ public class Server {
 
     private void workerCreation(ServerSocket serverSocket) throws IOException {
         Socket socket = serverSocket.accept();
-        OutputWorker outWorker = new OutputWorker(socket, data);
+        OutputWorker outWorker = new OutputWorker(
+                new ObjectOutputStream(socket.getOutputStream()),
+                data
+        );
         Thread outputWorker = new Thread(outWorker);
-        Thread inputWorker = new Thread(new InputWorker(socket, outWorker, handler, data));
+        Thread inputWorker = new Thread(new InputWorker(
+                new ObjectInputStream(socket.getInputStream()),
+                outWorker,
+                handler,
+                data
+        ));
         outputWorker.start();
         inputWorker.start();
     }

--- a/fagiServer/src/main/java/com/fagi/worker/InputWorker.java
+++ b/fagiServer/src/main/java/com/fagi/worker/InputWorker.java
@@ -51,7 +51,7 @@ public class InputWorker extends Worker implements InputAgent {
 
     @Override
     public void run() {
-        while (running) {
+        while (isWorkerRunningStrategy.isRunning()) {
             System.out.println("Running");
             try {
                 Object input = objIn.readObject();

--- a/fagiServer/src/main/java/com/fagi/worker/InputWorker.java
+++ b/fagiServer/src/main/java/com/fagi/worker/InputWorker.java
@@ -14,7 +14,6 @@ import com.fagi.model.Data;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.ObjectInputStream;
-import java.net.Socket;
 import java.net.SocketException;
 
 /**
@@ -23,8 +22,8 @@ import java.net.SocketException;
 public class InputWorker extends Worker implements InputAgent {
     private final InputHandler inputHandler;
     private final Data data;
-    private ObjectInputStream objIn;
-    private OutputWorker out;
+    private final ObjectInputStream objIn;
+    private final OutputWorker out;
     private String myUserName = null;
 
     private EncryptionAlgorithm<AESKey> aes;
@@ -34,7 +33,7 @@ public class InputWorker extends Worker implements InputAgent {
             ObjectInputStream objIn,
             OutputWorker out,
             ConversationHandler handler,
-            Data data) throws IOException {
+            Data data) {
         this.data = data;
         // TODO: This sysout does not make sense. Should be in the run method or where the thread is started.
         // https://trello.com/c/SVazRIgj/58-inputworker-should-not-print-starting-an-input-thread-in-its-constructor
@@ -66,11 +65,11 @@ public class InputWorker extends Worker implements InputAgent {
             } catch (EOFException | SocketException eof) {
                 running = false;
                 System.out.println("Logging out user " + myUserName);
-                out.running = false;
+                out.setRunning(false);
                 data.userLogout(myUserName);
             } catch (Exception e) {
                 running = false;
-                out.running = false;
+                out.setRunning(false);
                 System.out.println("Something went wrong in a input worker while loop " + e);
                 e.printStackTrace();
                 System.out.println("Logging out user " + myUserName);

--- a/fagiServer/src/main/java/com/fagi/worker/InputWorker.java
+++ b/fagiServer/src/main/java/com/fagi/worker/InputWorker.java
@@ -31,7 +31,7 @@ public class InputWorker extends Worker implements InputAgent {
     private boolean sessionCreated = false;
 
     public InputWorker(
-            Socket socket,
+            ObjectInputStream objIn,
             OutputWorker out,
             ConversationHandler handler,
             Data data) throws IOException {
@@ -39,7 +39,7 @@ public class InputWorker extends Worker implements InputAgent {
         // TODO: This sysout does not make sense. Should be in the run method or where the thread is started.
         // https://trello.com/c/SVazRIgj/58-inputworker-should-not-print-starting-an-input-thread-in-its-constructor
         System.out.println("Starting an input thread");
-        objIn = new ObjectInputStream(socket.getInputStream());
+        this.objIn = objIn;
         this.out = out;
         this.inputHandler = new InputHandler(
                 this,
@@ -121,5 +121,13 @@ public class InputWorker extends Worker implements InputAgent {
     @Override
     public InputHandler getInputHandler() {
         return inputHandler;
+    }
+
+    public boolean isSessionCreated() {
+        return sessionCreated;
+    }
+
+    public EncryptionAlgorithm<AESKey> getAes() {
+        return aes;
     }
 }

--- a/fagiServer/src/main/java/com/fagi/worker/InputWorker.java
+++ b/fagiServer/src/main/java/com/fagi/worker/InputWorker.java
@@ -55,6 +55,8 @@ public class InputWorker extends Worker implements InputAgent {
             System.out.println("Running");
             try {
                 Object input = objIn.readObject();
+
+                // TODO: We should only accept encrypted objects. This will be fixed in https://trello.com/c/8ieB7CSV
                 if (input instanceof byte[]) {
                     input = decryptAndConvertToObject((byte[]) input);
                 }

--- a/fagiServer/src/main/java/com/fagi/worker/OutputWorker.java
+++ b/fagiServer/src/main/java/com/fagi/worker/OutputWorker.java
@@ -16,7 +16,6 @@ import com.fagi.model.messages.lists.ListAccess;
 
 import java.io.IOException;
 import java.io.ObjectOutputStream;
-import java.net.Socket;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -37,9 +36,9 @@ public class OutputWorker extends Worker implements OutputAgent {
     private final ListAccess<FriendRequest> currentRequests = new DefaultListAccess<>(new ArrayList<>());
 
     public OutputWorker(
-            Socket socket,
-            Data data) throws IOException {
-        objOut = new ObjectOutputStream(socket.getOutputStream());
+            ObjectOutputStream objOut,
+            Data data) {
+        this.objOut = objOut;
         this.data = data;
     }
 

--- a/fagiServer/src/main/java/com/fagi/worker/OutputWorker.java
+++ b/fagiServer/src/main/java/com/fagi/worker/OutputWorker.java
@@ -44,7 +44,7 @@ public class OutputWorker extends Worker implements OutputAgent {
 
     @Override
     public void run() {
-        while (running) {
+        while (isWorkerRunningStrategy.isRunning()) {
             System.out.println("Running");
             try {
                 sendIncMessages();

--- a/fagiServer/src/main/java/com/fagi/worker/Worker.java
+++ b/fagiServer/src/main/java/com/fagi/worker/Worker.java
@@ -1,11 +1,29 @@
 package com.fagi.worker;
+
 /*
  * Copyright (c) 2011. Nicklas 'MiNiWolF' Pingel and Jonas 'Jonne' Hartwig
  * Worker.java
  *
  * Worker thread for each client.
  */
+import com.fagi.worker.running.CheckFieldRunningStrategy;
+import com.fagi.worker.running.IsWorkerRunningStrategy;
 
-abstract class Worker implements Runnable {
+public abstract class Worker implements Runnable {
+    // TODO: Rework using running and the IsWorkerRunningStrategy
+    // Trello issue: https://trello.com/c/8cEhrobt
     boolean running = true;
+    protected IsWorkerRunningStrategy isWorkerRunningStrategy = new CheckFieldRunningStrategy(this);
+
+    public boolean isRunning() {
+        return running;
+    }
+
+    /**
+     * Used by tests to change the strategy used to check if worker is running
+     * @param strategy the strategy to set
+     */
+    void setIsWorkerRunningStrategy(IsWorkerRunningStrategy strategy) {
+        isWorkerRunningStrategy = strategy;
+    }
 }

--- a/fagiServer/src/main/java/com/fagi/worker/running/CheckFieldRunningStrategy.java
+++ b/fagiServer/src/main/java/com/fagi/worker/running/CheckFieldRunningStrategy.java
@@ -2,9 +2,15 @@ package com.fagi.worker.running;
 
 import com.fagi.worker.Worker;
 
+/**
+ * This strategy simply returns the value of {@link Worker#isRunning()}
+ */
 public class CheckFieldRunningStrategy implements IsWorkerRunningStrategy {
     private final Worker worker;
 
+    /**
+     * @param worker the worker the strategy should check on
+     */
     public CheckFieldRunningStrategy(Worker worker) {
         this.worker = worker;
     }

--- a/fagiServer/src/main/java/com/fagi/worker/running/CheckFieldRunningStrategy.java
+++ b/fagiServer/src/main/java/com/fagi/worker/running/CheckFieldRunningStrategy.java
@@ -1,0 +1,16 @@
+package com.fagi.worker.running;
+
+import com.fagi.worker.Worker;
+
+public class CheckFieldRunningStrategy implements IsWorkerRunningStrategy {
+    private final Worker worker;
+
+    public CheckFieldRunningStrategy(Worker worker) {
+        this.worker = worker;
+    }
+
+    @Override
+    public boolean isRunning() {
+        return worker.isRunning();
+    }
+}

--- a/fagiServer/src/main/java/com/fagi/worker/running/IsWorkerRunningStrategy.java
+++ b/fagiServer/src/main/java/com/fagi/worker/running/IsWorkerRunningStrategy.java
@@ -2,8 +2,12 @@ package com.fagi.worker.running;
 
 /**
  * This strategy tells our workers whether they are running or not. This is introduced to make testing easier and
- * potentially make more complex ways of testing if a worker should be running than a field
+ * potentially make more complex checks on whether a worker should be running or not
  */
 public interface IsWorkerRunningStrategy {
+    /**
+     * Indicates whether a given worker is running or not
+     * @return true if the worker is running, false if not
+     */
     boolean isRunning();
 }

--- a/fagiServer/src/main/java/com/fagi/worker/running/IsWorkerRunningStrategy.java
+++ b/fagiServer/src/main/java/com/fagi/worker/running/IsWorkerRunningStrategy.java
@@ -1,0 +1,9 @@
+package com.fagi.worker.running;
+
+/**
+ * This strategy tells our workers whether they are running or not. This is introduced to make testing easier and
+ * potentially make more complex ways of testing if a worker should be running than a field
+ */
+public interface IsWorkerRunningStrategy {
+    boolean isRunning();
+}

--- a/fagiServer/src/test/java/com/fagi/handler/inputhandler/NotValidRequestTests.java
+++ b/fagiServer/src/test/java/com/fagi/handler/inputhandler/NotValidRequestTests.java
@@ -11,7 +11,7 @@ import java.io.PrintStream;
 
 import static org.mockito.Mockito.when;
 
-public class UnknownRequestTests extends BaseInputHandlerTest {
+public class NotValidRequestTests extends BaseInputHandlerTest {
     private final PrintStream standardOut = System.out;
     private final ByteArrayOutputStream outputStreamCaptor = new ByteArrayOutputStream();
 
@@ -41,6 +41,28 @@ public class UnknownRequestTests extends BaseInputHandlerTest {
 
         Assertions.assertEquals(
                 "Unknown handle: " + UnknownRequest.class,
+                outputStreamCaptor
+                        .toString()
+                        .trim()
+        );
+    }
+
+    @Test
+    void givenInputIsNull_ShouldGiveNoResponse() {
+        inputHandler.handleInput(null);
+
+        OutputAgentTestUtil.verifyNoResponseOfType(
+                outputAgent,
+                Object.class
+        );
+    }
+
+    @Test
+    void givenInputIsNull_ShouldPrintMessageInSysOut() {
+        inputHandler.handleInput(null);
+
+        Assertions.assertEquals(
+                "Input is null. Doing nothing.",
                 outputStreamCaptor
                         .toString()
                         .trim()


### PR DESCRIPTION
## Intro

In this pull request small changes have been made to make Workers more testable

## Worker changes

### IsWorkerRunningStrategy

A strategy has been introduced to be used to check if a Worker is running or not. This is done as a simle `while (running)` pattern blocked the test thread, which forced unit tests to create Threads. This introduced issues with waiting (`Thread.sleep(x)`), with using `Mockito.mockStatic` because of scope issues.

This strategy is a temporary solution, until we have made a better way to determine if Workers for a particular user should be running.

### ObjectInputStream/ObjectOutputStream

Previously the InputWorker and OutputWorker created their own ObjectInputStream/ObjectOutputStream from the socket passed into the constructor. This caused issues in unit tests as a the constructor for these objects did not work when they were given mocks.

To fix this issue, the Workers now take the ObjectInputStream/ObjectOutputStream as constructor parameters, rather than a Socket. Thus allowing unit tests to simply mocking the ObjectInputStream/ObjectOutputStream objects.

## Additional changes

### InputHandler

The InputHandler did not handle null gracefully when passed to the `InputHandler#handleInput`. When our Conversion of byte arrays into objects fails, it sets the input to null, and passes it to `InputHandler#handleInput`, thus causing a NullPointerException. 

Thus an extra if-check has been introduced as the first check in `InputHandler#handleInput` to handle the null value gracefully.

Additional tests have been introduced to test this case.